### PR TITLE
Migrate activity roles to do comparisons on activity name instead of session id

### DIFF
--- a/src/config/activity-roles/loader.spec.ts
+++ b/src/config/activity-roles/loader.spec.ts
@@ -4,39 +4,39 @@ describe('config/activity-roles', () => {
     it('should parse a single associations', () => {
         const key = 'DISCORD_CROSSPOSTER_SERVICE_ACTIVITY_ROLES_ASSOCIATIONS';
         // guildId1->activityId1@roleId1#roleId2#roleId3$activityId2@roleId1#roleId2,guildId2->activityId1@roleId1#roleId2
-        const value = '00->01@02';
+        const value = '00->Valorant@02';
         const { associations } = loadConfig({ [key]: value });
 
         // Guild 1
         expect(associations.has('00')).toBeTruthy();
         // Activity 1
-        expect(associations.get('00')?.has('01')).toBeTruthy();
-        expect(associations.get('00')?.get('01')?.has('02')).toBeTruthy();
+        expect(associations.get('00')?.has('Valorant')).toBeTruthy();
+        expect(associations.get('00')?.get('Valorant')?.has('02')).toBeTruthy();
     });
 
     it('should parse multiple associations', () => {
         const key = 'DISCORD_CROSSPOSTER_SERVICE_ACTIVITY_ROLES_ASSOCIATIONS';
         // guildId1->activityId1@roleId1#roleId2#roleId3$activityId2@roleId1#roleId2,guildId2->activityId1@roleId1#roleId2
-        const value = '00->01@02#03#04$05@06#07,08->09@10#11';
+        const value = '00->Valorant@02#03#04$Apex Legends@06#07,08->COD: Warzone@10#11';
         const { associations } = loadConfig({ [key]: value });
 
         // Guild 1
         expect(associations.has('00')).toBeTruthy();
         // Activity 1
-        expect(associations.get('00')?.has('01')).toBeTruthy();
-        expect(associations.get('00')?.get('01')?.has('02')).toBeTruthy();
-        expect(associations.get('00')?.get('01')?.has('03')).toBeTruthy();
-        expect(associations.get('00')?.get('01')?.has('04')).toBeTruthy();
+        expect(associations.get('00')?.has('Valorant')).toBeTruthy();
+        expect(associations.get('00')?.get('Valorant')?.has('02')).toBeTruthy();
+        expect(associations.get('00')?.get('Valorant')?.has('03')).toBeTruthy();
+        expect(associations.get('00')?.get('Valorant')?.has('04')).toBeTruthy();
         // Activity 2
-        expect(associations.get('00')?.has('05')).toBeTruthy();
-        expect(associations.get('00')?.get('05')?.has('06')).toBeTruthy();
-        expect(associations.get('00')?.get('05')?.has('07')).toBeTruthy();
+        expect(associations.get('00')?.has('Apex Legends')).toBeTruthy();
+        expect(associations.get('00')?.get('Apex Legends')?.has('06')).toBeTruthy();
+        expect(associations.get('00')?.get('Apex Legends')?.has('07')).toBeTruthy();
 
         // Guild 2
         expect(associations.get('08')).toBeTruthy();
         // Activity 1
-        expect(associations.get('08')?.has('09')).toBeTruthy();
-        expect(associations.get('08')?.get('09')?.has('10')).toBeTruthy();
-        expect(associations.get('08')?.get('09')?.has('11')).toBeTruthy();
+        expect(associations.get('08')?.has('COD: Warzone')).toBeTruthy();
+        expect(associations.get('08')?.get('COD: Warzone')?.has('10')).toBeTruthy();
+        expect(associations.get('08')?.get('COD: Warzone')?.has('11')).toBeTruthy();
     });
 });

--- a/src/config/activity-roles/loader.ts
+++ b/src/config/activity-roles/loader.ts
@@ -15,7 +15,7 @@ function loadAssociations(env: Record<string, string | undefined>): ActivityRole
     /**
      * Assuming the format is like:
      *
-     * guildId1->activityId1@roleId1#roleId2#roleId3$activityId2@roleId1#roleId2,guildId2->activityId1@roleId1#roleId2
+     * guildId1->game name 1@roleId1#roleId2#roleId3$game name 2@roleId1#roleId2,guildId2->game name 3@roleId1#roleId2
      */
     const raw = env.DISCORD_CROSSPOSTER_SERVICE_ACTIVITY_ROLES_ASSOCIATIONS;
     if (raw) {

--- a/src/service/discord/modules/activity-roles/metrics.ts
+++ b/src/service/discord/modules/activity-roles/metrics.ts
@@ -8,6 +8,6 @@ export const PRESENCE_CHANGES = new PromClient.Counter({
 
 export const ROLES_ISSUED = new PromClient.Counter({
     help: 'A counter for how many Discord roles have been granted for activity-role associations.',
-    labelNames: ['guild_id', 'role_id'],
+    labelNames: ['guild_id', 'role_id', 'activity_name'],
     name: 'discord_activity_roles_issued',
 });

--- a/src/service/discord/modules/activity-roles/module.ts
+++ b/src/service/discord/modules/activity-roles/module.ts
@@ -78,7 +78,7 @@ export class ActivityRolesModule extends Module implements IModule {
             if (activity.type !== 'PLAYING') {
                 continue;
             }
-            console.log(`Activity ${activity.id} (${activity.name}) is being played by ${memberStr} in ${guildStr}.`);
+            console.log(`Activity '${activity.name}' is being played by ${memberStr} in ${guildStr}.`);
 
             /* Add any roles to the grant set if any are specified for this activity */
             for (const roleId of this.logic.getRoles(guild.id, activity.name)) {


### PR DESCRIPTION
Robinlemon ba09c85 Update config loader tests for string app ids
Robinlemon 46cf1b4 Allow only playing activities and comment log calls
Robinlemon 3ca3f2f Use activity name and increment metrics
Robinlemon 70a1cd4 Remove id logging for activities