### PR TITLE
Add fuzzy matching for activity roles logic

### DIFF
--- a/src/service/discord/modules/activity-roles/logic.spec.ts
+++ b/src/service/discord/modules/activity-roles/logic.spec.ts
@@ -1,0 +1,19 @@
+import type { RoleID } from './logic';
+import { ActivityRolesLogic } from './logic';
+
+describe('Modules/ActivityRoles/Logic', () => {
+    it('Should match all of these games', () => {
+        const guildId = '105753365916422144';
+        const game = 'Apex Legends';
+        const roleId = '12121221';
+        const associations = new Map<string, Map<string, Set<RoleID>>>([
+            [guildId, new Map([[game, new Set<RoleID>([roleId])]])],
+        ]);
+        const logic = new ActivityRolesLogic({ associations });
+
+        expect([...logic.getRoles(guildId, 'Minecraft')]).toHaveLength(0);
+        expect([...logic.getRoles(guildId, 'Apex Legends')]).toHaveLength(1);
+        expect([...logic.getRoles(guildId, 'Apex Legends™️')]).toHaveLength(1);
+        expect([...logic.getRoles(guildId, 'Apex Legends™️ sur GeForce Now')]).toHaveLength(1);
+    });
+});

--- a/src/service/discord/modules/activity-roles/logic.ts
+++ b/src/service/discord/modules/activity-roles/logic.ts
@@ -11,21 +11,32 @@ export interface IActivityRolesLogicOptions {
 export class ActivityRolesLogic implements IActivityRolesLogic {
     protected _associations: Map<string, Map<string, Set<RoleID>>>;
 
-    public constructor({ associations: roles }: IActivityRolesLogicOptions) {
-        this._associations = roles;
+    public constructor({ associations }: IActivityRolesLogicOptions) {
+        this._associations = new Map(
+            [...associations.entries()].map(([guildId, games]) => {
+                return [
+                    guildId,
+                    new Map(
+                        [...games.entries()].map(([game, roles]) => {
+                            return [game.toLowerCase(), roles];
+                        })
+                    ),
+                ];
+            })
+        );
     }
 
-    public *getRoles(guildId: string, activityId: string) {
+    public *getRoles(guildId: string, name: string) {
         const games = this._associations.get(guildId);
         if (!games) {
             return;
         }
 
-        const roles = games.get(activityId);
-        if (!roles) {
-            return;
+        name = name.toLowerCase();
+        for (const [game, roles] of games.entries()) {
+            if (name.includes(game)) {
+                yield* roles.values();
+            }
         }
-
-        yield* roles.values();
     }
 }


### PR DESCRIPTION
Robinlemon 1e84c63 Load cached async roles per-guild for name context
Robinlemon 64591fc Make activity name matching logic case insensitive and fuzzy